### PR TITLE
Fix/tests on tb3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.5)
+project(ros2_teleop_snap)
+
+find_package(ament_cmake REQUIRED)
+
+ament_package()

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2_teleop_snap</name>
+  <version>0.0.0</version>
+  <description>meta package for ros2 teleop snap dependencies</description>
+  <maintainer email="canonical-robotics-brand@canonical.com">ubuntu-robotics</maintainer>
+  <license>GPLv3</license>
+
+  <exec_depend>teleop_twist_joy</exec_depend>
+  <exec_depend>teleop_twist_keyboard</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
+
+</package>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,7 +27,7 @@ description: |
     The upstream package offers some default joystick configurations.
     Those can be set up with the joy-config parameter as follows:
 
-    snap set joy-config="ps3"
+    snap set ros2-teleop joy-config="ps3"
 
     In alternative, a custom configuration file can be used. The file can be provided
     by means of a URL. In such case, the snap will download the file and

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -117,13 +117,11 @@ apps:
 
 parts:
   ros2-teleop:
-    plugin: nil
+    plugin: colcon
+    source: .
     stage-packages:
       - wget
       - libssl3
-      - ros-humble-teleop-twist-joy
-      - ros-humble-teleop-twist-keyboard
-      - ros-humble-topic-tools
 
   # copy local scripts to the snap
   local-files:


### PR DESCRIPTION
Divide by 3 the size of the snap.
`Stage-packages` are not yet considered by the ROS 2 extension.