### PR TITLE
Jazzy: remove concurrency

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -22,10 +22,6 @@ on:
         type: string
         default: ${{ github.ref }}
 
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   snap:
     uses: canonical/robotics-actions-workflows/.github/workflows/snap.yaml@main


### PR DESCRIPTION
the concurrency currently fails in the monthly jobs, because we have 2 flows running with the same id