### PR TITLE
Humble: remove concurrency

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -19,9 +19,6 @@ on:
         type: string
         default: ${{ github.ref }}
 
-concurrency:
-  group: ${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 
 jobs:
   snap:


### PR DESCRIPTION
the concurrency currently fails in the monthly jobs, because we have 2 flows running with the same id